### PR TITLE
Add evaluate in Github Actions

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -1,0 +1,21 @@
+name: Evaluate
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  evaluator:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - run: python3 evaluate.py

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -35,5 +35,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: "```${{ steps.evaluation.outputs.result }}```"
+          msg: "```\n${{ steps.evaluation.outputs.result }}\n```"
           check_for_duplicate_msg: true

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -18,4 +18,18 @@ jobs:
         with:
           python-version: '3.7'
 
-      - run: python3 evaluate.py
+      - name: Run Evaluation
+        id: evaluation
+        run: |
+          RESULT=$(python3 evaluate.py)
+          echo "${RESULT}"
+          echo "::set-output name=result::${RESULT}"
+
+      - name: Send Results as Comment
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: "${{ steps.evaluation.outputs.result }}"
+          check_for_duplicate_msg: true

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -23,6 +23,10 @@ jobs:
         run: |
           RESULT=$(python3 evaluate.py)
           echo "${RESULT}"
+          # hack for multiline output
+          RESULT="${RESULT//'%'/'%25'}"
+          RESULT="${RESULT//$'\n'/'%0A'}"
+          RESULT="${RESULT//$'\r'/'%0D'}"
           echo "::set-output name=result::${RESULT}"
 
       - name: Send Results as Comment

--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -35,5 +35,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          msg: "${{ steps.evaluation.outputs.result }}"
+          msg: "```${{ steps.evaluation.outputs.result }}```"
           check_for_duplicate_msg: true


### PR DESCRIPTION
New workflows disabled from forks, therefore I tested it in PR on cloned repo: https://github.com/ForkLab/article-extraction-benchmark/pull/1