### PR TITLE
Run actions using target config

### DIFF
--- a/.github/workflows/evaluate.yml
+++ b/.github/workflows/evaluate.yml
@@ -1,7 +1,7 @@
 name: Evaluate
 
 on:
-  pull_request:
+  pull_request_target:
   push:
     branches:
       - master


### PR DESCRIPTION
This should fix the permission problem when posting a comment in PRs from forks, like in https://github.com/scrapinghub/article-extraction-benchmark/pull/10.
Based on https://github.com/actions/first-interaction/issues/10#issuecomment-670968624